### PR TITLE
Fix overworld seasonal music being stopped on STATE_CHANGE.

### DIFF
--- a/src/client/audio_engine.cpp
+++ b/src/client/audio_engine.cpp
@@ -262,7 +262,13 @@ void AudioEngine::playGlobalLoop(uint32_t soundId, float volume) {
   }
 
   auto it = sounds_.find(soundId);
-  if (it == sounds_.end()) return;
+  if (it == sounds_.end()) {
+    std::fprintf(stderr,
+                 "AudioEngine: global loop sound id %u not loaded "
+                 "(missing assets/sounds?)\n",
+                 soundId);
+    return;
+  }
 
   if (globalMusicHandle_ != 0) {
     globalMusicFadeOutHandle_ = globalMusicHandle_;

--- a/src/client/client_game.cpp
+++ b/src/client/client_game.cpp
@@ -235,15 +235,23 @@ void registerClientHandlers(ClientNetwork& network) {
         shared::StateChangePacket pkt;
         std::memcpy(&pkt, data, sizeof(pkt));
         game.currentGameState = pkt.state;
-        game.audio.stopAllGlobalLoops();
         if (pkt.state == shared::GameStateType::MAZE) {
+          game.audio.stopAllGlobalLoops();
           game.audio.playGlobalLoop(
               static_cast<uint32_t>(shared::SoundId::MAZE_MUSIC), 0.3f);
         } else if (pkt.state == shared::GameStateType::CREDITS) {
+          game.audio.stopAllGlobalLoops();
           game.audio.playGlobalLoop(
               static_cast<uint32_t>(shared::SoundId::CREDITS_MUSIC), 0.3f);
+        } else if (pkt.state == shared::GameStateType::OVERWORLD) {
+          // Stop minigame/credits loops only. Season loops come from
+          // SEASON_MUSIC; do not stopAll here or a reordered packet can mute
+          // overworld music until the next sync.
+          game.audio.stopGlobalLoop(
+              static_cast<uint32_t>(shared::SoundId::MAZE_MUSIC));
+          game.audio.stopGlobalLoop(
+              static_cast<uint32_t>(shared::SoundId::CREDITS_MUSIC));
         }
-        // Overworld seasonal music arrives via SEASON_MUSIC.
       });
 
   network.dispatcher().on(


### PR DESCRIPTION
Only stop all global loops when entering maze or credits; on overworld stop minigame tracks only so SEASON_MUSIC is not wiped by packet order. Log to stderr when a global loop sound failed to load.